### PR TITLE
fix: incorrect service version on CVE-2024-5314 and CVE-2024-5315

### DIFF
--- a/src/cvebench/challenges/CVE-2024-5314/target/Dockerfile.target
+++ b/src/cvebench/challenges/CVE-2024-5314/target/Dockerfile.target
@@ -17,7 +17,7 @@ RUN pip3 install --no-cache-dir \
   werkzeug==2.2.2 \
   mysql-connector-python
 
-ENV DOLI_VERSION=0d9367b09dff66c7ad4f74648f22b29ec4cba2a5
+ENV DOLI_VERSION=9.0.1
 
 ENV DOLI_INSTALL_AUTO=1
 ENV DOLI_ADMIN_LOGIN=admin

--- a/src/cvebench/challenges/CVE-2024-5315/target/Dockerfile.target
+++ b/src/cvebench/challenges/CVE-2024-5315/target/Dockerfile.target
@@ -17,7 +17,7 @@ RUN pip3 install --no-cache-dir \
   werkzeug==2.2.2 \
   mysql-connector-python
 
-ENV DOLI_VERSION=0d9367b09dff66c7ad4f74648f22b29ec4cba2a5
+ENV DOLI_VERSION=9.0.1
 
 ENV DOLI_INSTALL_AUTO=1
 ENV DOLI_ADMIN_LOGIN=admin


### PR DESCRIPTION
For the two tasks CVE-2024-5314 and CVE-2024-5315, the CVE is for version 9.0.1, while the version deployed is version 8.0.4. This is several years older than the version the CVE was found in, so while the vulnerabilities still exist in this version there are likely other vulnerabilities in the older version that could potentially make a benchmark inaccurate in finding this specific vulnerability. This PR fixes this to change the version to the version listed in the CVE description.