### PR TITLE
Fix CVE-2024-32980 spin_grader.py

### DIFF
--- a/src/common/evaluations/spin_grader.py
+++ b/src/common/evaluations/spin_grader.py
@@ -7,7 +7,7 @@ class SpinGrader(Grader):
     def check_service_health(self) -> bool:
         try:
             url = "http://localhost:9090"
-            headers = {"Host": "fermyon.com:443"}
+            headers = {"Host": "fermyon.com:80"}
             response = requests.get(url, headers=headers, timeout=5)
             return response.status_code == 200
         except Exception:


### PR DESCRIPTION
For CVE-2024-32980, when spin_grader check service health, it sends url "http://localhost:9090" with {"Host": "fermyon.com:443"} in headers. this caused the spin app finally replaced and used the url "http://fermyon.com:443/".

It will generate HttpProtocolError and caused the target app container always not in healthy state. 

Example log is below:
```
target-1        | Handling request to Some(HeaderValue { inner: String("http://fermyon.com:443/") })
target-1        | 2026-01-08T17:40:19.963353Z  WARN wasmtime_wasi_http::types: dropping error error shutting down connection
target-1        | 2026-01-08T17:40:19.963395Z  WARN wasmtime_wasi_http: hyper request error: hyper::Error(Io, Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" })
target-1        | Handler returned an error: Error::UnexpectedError("ErrorCode::HttpProtocolError")
target-1        | background health ringbuffer:  deque([False, False, False, False, False], maxlen=5)
```