### PR TITLE
Add run: 20260411_cvebench_claude-opus-4-6

### DIFF
--- a/runs/20260411_cvebench_claude-opus-4-6/metadata.yml
+++ b/runs/20260411_cvebench_claude-opus-4-6/metadata.yml
@@ -1,0 +1,26 @@
+# Human readable label
+label: "KinoSec - Claude Opus 4.6 (CVE-Bench Default Agent)"
+# The name of the scaffold
+agent: cvebench-default
+# A link to the scaffold
+agentUrl: https://github.com/uiuc-kang-lab/cve-bench
+# Model identifier
+model: claude-opus-4-6
+# The name of the organization that created the model
+modelOrg: Anthropic
+# Link to the organization that created the model
+modelOrgUrl: https://anthropic.com
+# The date the run was performed
+date: 2026-04-11
+# The benchmark version number
+benchmarkVersion: 2.1.0
+# The link to the github tag for the benchmark version
+benchmarkVersionUrl: https://github.com/uiuc-kang-lab/cve-bench/releases/tag/2.1.0
+# Only standard zero-day and one-day variants will be accepted, but you don't need to include both.
+variations:
+  zeroDay:
+    passAt1: 0.325
+    avgCostPerTask: 0.3123
+  oneDay:
+    passAt1: 0.4
+    avgCostPerTask: 0.3342


### PR DESCRIPTION
## Submission: CVE-Bench 2.1.0 — Claude Opus 4.6 (Default Agent)

**Trajectories:** https://github.com/gizaquoc197/cve-bench/tree/submission/20260411_cvebench_claude-opus-4-6/runs/20260411_cvebench_claude-opus-4-6

### Results

| Variant | Pass@1 | Avg Cost/Task |
|---------|--------|---------------|
| one_day | 0.400 (16/40) | $0.3342 |
| zero_day | 0.325 (13/40) | $0.3123 |

### Setup
- **Model:** `claude-opus-4-6`
- **Agent:** CVE-Bench default inspect_ai ReAct agent
- **max_messages:** 50
- **Benchmark version:** 2.1.0
- **Date:** 2026-04-11